### PR TITLE
内部でTanStack Tableを使うテーブルコンポーネントの実装

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,10 +1,163 @@
-import { DemoTable } from "./components/DemoTable";
+import { useEffect, useMemo, useState } from "react";
+import { Table } from "./components/Table";
+import {
+  createColumnHelper,
+  useReactTable,
+  PaginationState,
+  SortingState,
+} from "./functions/table";
+import { fetchPaginationData, fetchSortedData } from "./fetchData";
+
+type Nus3Info = {
+  id: string;
+  name: string;
+  creator: string;
+  createdAt: string;
+  description: string;
+};
+
+const defaultData: Nus3Info[] = [
+  {
+    id: "1",
+    name: "name-1",
+    creator: "creator-1",
+    createdAt: "2021-01-01",
+    description: "description-1",
+  },
+  {
+    id: "2",
+    name: "name-2",
+    creator: "creator-2",
+    createdAt: "2021-01-01",
+    description: "description-2",
+  },
+  {
+    id: "3",
+    name: "name-3",
+    creator: "creator-3",
+    createdAt: "2021-01-01",
+    description: "description-3",
+  },
+];
+
+const columnHelper = createColumnHelper<Nus3Info>();
+const columns = [
+  columnHelper.display({
+    id: "edit",
+    cell: (props) => (
+      <button
+        onClick={() => {
+          console.info(props.row, "編集する行情報");
+        }}
+      >
+        編集
+      </button>
+    ),
+  }),
+  columnHelper.accessor("id", {
+    header: "ID",
+    cell: (info) => info.getValue(),
+  }),
+  columnHelper.accessor("name", {
+    header: "名前",
+    cell: (info) => info.getValue(),
+  }),
+  columnHelper.accessor("creator", {
+    header: "作成者",
+    cell: (info) => info.getValue(),
+  }),
+  columnHelper.accessor("createdAt", {
+    header: "作成日時",
+    cell: (info) => info.getValue(),
+  }),
+  columnHelper.accessor("description", {
+    header: "概要",
+    id: "description",
+    cell: (info) => (
+      <span style={{ minWidth: "300px", display: "inline-block" }}>
+        {info.getValue()}
+      </span>
+    ),
+  }),
+  columnHelper.display({
+    id: "delete",
+    cell: (props) => (
+      <button
+        onClick={() => {
+          console.info(props.row, "削除する行情報");
+        }}
+      >
+        削除
+      </button>
+    ),
+  }),
+];
 
 function App() {
+  const [data, setData] = useState(() => [...defaultData]);
+  const [sorting, setSorting] = useState<SortingState>([]);
+  const [{ pageIndex, pageSize }, setPagination] = useState<PaginationState>({
+    pageIndex: 0,
+    pageSize: 3,
+  });
+  const [totalCount, setTotalCount] = useState(0);
+
+  const pagination = useMemo(
+    () => ({
+      pageIndex,
+      pageSize,
+    }),
+    [pageIndex, pageSize]
+  );
+
+  // useEffectを使わずにonSortingChangeの中でいい感じにできそうな気もする
+  useEffect(() => {
+    const handleChangeSort = async () => {
+      const data = await fetchSortedData(sorting);
+      setData(data);
+    };
+
+    // サーバーサイド側の時は、データを取得するまではloadingの表示をしたほうが良さそう
+    handleChangeSort();
+  }, [sorting]);
+
+  // useEffectを使わずにonPaginationChangeの中でいい感じにできそうな気もする
+  useEffect(() => {
+    const handleChangePage = async () => {
+      const { data, count } = await fetchPaginationData(pageIndex);
+      setData(data);
+      setTotalCount(count);
+    };
+
+    // サーバーサイド側の時は、データを取得するまではloadingの表示をしたほうが良さそう
+    handleChangePage();
+  }, [pageIndex, pagination]);
+
+  const table = useReactTable({
+    data,
+    columns,
+    state: {
+      sorting,
+      pagination,
+    },
+    pageCount: 3, // apiから取得する
+    onPaginationChange: setPagination,
+    onSortingChange: setSorting,
+    debugTable: true,
+    manualSorting: true,
+    manualPagination: true,
+    enableMultiSort: false,
+  });
+
   return (
     <>
       <h1>TanStack Table Demo</h1>
-      <DemoTable></DemoTable>
+      <Table
+        table={table}
+        pageIndex={pageIndex}
+        pageSize={pageSize}
+        totalCount={totalCount}
+      />
     </>
   );
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,10 +1,10 @@
-import { Table } from "./components/Table";
+import { DemoTable } from "./components/DemoTable";
 
 function App() {
   return (
     <>
       <h1>TanStack Table Demo</h1>
-      <Table></Table>
+      <DemoTable></DemoTable>
     </>
   );
 }

--- a/src/components/DemoTable.tsx
+++ b/src/components/DemoTable.tsx
@@ -73,12 +73,12 @@ const columns = [
     header: "作成日時",
     cell: (info) => info.getValue(),
   }),
-  columnHelper.display({
+  columnHelper.accessor("description", {
     header: "概要",
     id: "description",
     cell: (info) => (
       <span style={{ minWidth: "300px", display: "inline-block" }}>
-        {info.row.original.description}
+        {info.getValue()}
       </span>
     ),
   }),
@@ -154,6 +154,7 @@ export const DemoTable: FC<DemoTableProps> = () => {
     debugTable: true,
     manualSorting: true,
     manualPagination: true,
+    enableMultiSort: false,
   });
 
   const from = useMemo(() => pageIndex * pageSize + 1, [pageIndex, pageSize]);

--- a/src/components/DemoTable.tsx
+++ b/src/components/DemoTable.tsx
@@ -96,11 +96,11 @@ const columns = [
   }),
 ];
 
-type TableProps = {
+type DemoTableProps = {
   foo?: string;
 };
 
-export const Table: FC<TableProps> = () => {
+export const DemoTable: FC<DemoTableProps> = () => {
   const [data, setData] = useState(() => [...defaultData]);
   const [sorting, setSorting] = useState<SortingState>([]);
   const [{ pageIndex, pageSize }, setPagination] = useState<PaginationState>({

--- a/src/components/Table.tsx
+++ b/src/components/Table.tsx
@@ -1,0 +1,82 @@
+import { Table as TableInstance, flexRender } from "@tanstack/react-table";
+import { useMemo } from "react";
+import classes from "./Table.module.css";
+
+type TableProps<T> = {
+  table: TableInstance<T>;
+  totalCount: number;
+  pageIndex: number;
+  pageSize: number;
+};
+
+export const Table = <T extends object>({
+  table,
+  totalCount,
+  pageIndex,
+  pageSize,
+}: TableProps<T>) => {
+  const from = useMemo(() => pageIndex * pageSize + 1, [pageIndex, pageSize]);
+  const to = useMemo(() => from + pageSize - 1, [from, pageSize]);
+
+  return (
+    <div className={classes.wrapper}>
+      <div className={classes.pagination}>
+        {from} - {to} / {totalCount}件
+        <button
+          onClick={() => table.previousPage()}
+          disabled={!table.getCanPreviousPage()}
+        >
+          前へ
+        </button>
+        <button
+          onClick={() => table.nextPage()}
+          disabled={!table.getCanNextPage()}
+        >
+          次へ
+        </button>
+      </div>
+      <table className={classes.table}>
+        <thead>
+          {table.getHeaderGroups().map((headerGroup) => (
+            <tr key={headerGroup.id}>
+              {headerGroup.headers.map((header) => (
+                <th key={header.id} className={classes.th}>
+                  {header.isPlaceholder ? null : (
+                    <div
+                      className={
+                        header.column.getCanSort() ? classes.sortBtn : undefined
+                      }
+                      {...{
+                        onClick: header.column.getToggleSortingHandler(),
+                      }}
+                    >
+                      {flexRender(
+                        header.column.columnDef.header,
+                        header.getContext()
+                      )}
+                      {{
+                        asc: " 🔼",
+                        desc: " 🔽",
+                      }[header.column.getIsSorted() as string] ?? null}
+                    </div>
+                  )}
+                </th>
+              ))}
+            </tr>
+          ))}
+        </thead>
+        <tbody>
+          {table.getRowModel().rows.map((row) => (
+            <tr key={row.id}>
+              {row.getVisibleCells().map((cell) => (
+                <td key={cell.id} className={classes.td}>
+                  {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                </td>
+              ))}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+};

--- a/src/fetchData.ts
+++ b/src/fetchData.ts
@@ -1,5 +1,5 @@
 import { PaginationState, SortingState } from "@tanstack/react-table";
-import { Nus3Info } from "./components/Table";
+import { Nus3Info } from "./components/DemoTable";
 
 export const fetchSortedData = async (sorting: SortingState) => {
   await new Promise((r) => setTimeout(r, 500));

--- a/src/functions/table.ts
+++ b/src/functions/table.ts
@@ -1,0 +1,17 @@
+import {
+  RowData,
+  TableOptions,
+  getCoreRowModel,
+  useReactTable as useReactTableOrig,
+  createColumnHelper,
+  PaginationState,
+  SortingState,
+} from "@tanstack/react-table";
+
+export const useReactTable = <T extends RowData>(
+  options: Omit<TableOptions<T>, "getCoreRowModel">
+) => useReactTableOrig({ ...options, getCoreRowModel: getCoreRowModel() });
+
+export { createColumnHelper };
+
+export type { PaginationState, SortingState };


### PR DESCRIPTION
## REF

useReactTableでGitHubを全文検索したら、TanStack Tableが提供するAPIをre-exportしてる実装をしてるリポジトリを発見した
https://github.com/oxidecomputer/console

この実装であれば、テーブルのUI自体はUIライブラリ側(自分たち側)で定義でき、TanStack Tableの自由なカラム定義などはそのまま利用できるのでヨサソウ

- https://github.com/oxidecomputer/console/blob/e5b8d029d48b9d5c9212fbf5156d6a57cb0b5d5b/libs/table/react-table.ts#L19
- https://github.com/oxidecomputer/console/blob/e5b8d029d48b9d5c9212fbf5156d6a57cb0b5d5b/app/pages/settings/ProfilePage.tsx#L26
- https://github.com/oxidecomputer/console/blob/main/libs/table/Table.tsx#L22